### PR TITLE
Fixed the error resulting from EMM not correctly indicating having reached the last page

### DIFF
--- a/scraper_articles.R
+++ b/scraper_articles.R
@@ -273,6 +273,8 @@ while(page_count == -1 && curr_page <= max_page_count) {
   page_count <- get_page_count(page)
   curr_page <- get_current_page(page)
   ##
-  dump_parsed(curr_page, parse_page(page), merged=TRUE, appended=TRUE)
+  if(page_count > -3) {
+    dump_parsed(curr_page, parse_page(page), merged=TRUE, appended=TRUE)
+  }
 }
 


### PR DESCRIPTION
Sometimes EMM does not correctly signal having reached the last page (dunno why). This results in an error with the new merged output format (previously it would just have written empty files). 

The code just checks that the page status isn't -3 (past last page) before writing output.